### PR TITLE
Fix GI warnings, update deprecated GObject usage

### DIFF
--- a/activity.py
+++ b/activity.py
@@ -19,7 +19,7 @@ from gettext import gettext as _
 
 import gi
 gi.require_version('Gtk', '3.0')
-gi.require_version('GConf', '2.0')
+gi.require_version('Gio', '2.0')
 gi.require_version('Vte', '2.91')
 gi.require_version('Wnck', '3.0')
 

--- a/graphics.py
+++ b/graphics.py
@@ -13,6 +13,8 @@
 from gettext import gettext as _
 
 import gi
+gi.require_version('Gtk', '3.0')
+gi.require_version('Gdk', '3.0')
 gi.require_version('WebKit2', '4.0')
 
 from gi.repository import Gdk

--- a/reflectwindow.py
+++ b/reflectwindow.py
@@ -716,7 +716,7 @@ class ReflectionGrid(Gtk.EventBox):
             bundle_icons = utils.get_bundle_icons()
             x = 0
             y = 1
-            for bundle_id in bundle_icons.keys():
+            for bundle_id in list(bundle_icons.keys()):
                 icon_path = bundle_icons[bundle_id]
                 if icon_path is None:
                     continue

--- a/reflectwindow.py
+++ b/reflectwindow.py
@@ -16,6 +16,9 @@ import json
 from random import uniform
 from gettext import gettext as _
 
+import gi
+gi.require_version('Gtk', '3.0')
+
 from gi.repository import Gtk
 from gi.repository import Gdk
 from gi.repository import GObject

--- a/textchannelwrapper.py
+++ b/textchannelwrapper.py
@@ -442,7 +442,7 @@ class _BaseFileTransfer(GObject.GObject):
     def _get_transferred_bytes(self):
         return self._transferred_bytes
 
-    transferred_bytes = GObject.property(type=int,
+    transferred_bytes = GObject.Property(type=int,
                                          default=0,
                                          getter=_get_transferred_bytes,
                                          setter=_set_transferred_bytes)
@@ -462,7 +462,7 @@ class _BaseFileTransfer(GObject.GObject):
     def _get_state(self):
         return self._state
 
-    state = GObject.property(type=int, getter=_get_state, setter=_set_state)
+    state = GObject.Property(type=int, getter=_get_state, setter=_set_state)
 
     def cancel(self):
         '''

--- a/utils.py
+++ b/utils.py
@@ -25,13 +25,21 @@ import re
 import time
 import configparser
 
+
+import gi
+gi.require_version('Gtk', '3.0')
+gi.require_version('Gio', '2.0')
+gi.require_version('Vte', '2.91')
+gi.require_version('Wnck', '3.0')
+gi.require_version('SugarExt', '1.0')
+
 from gi.repository import Vte
 from gi.repository import Gio
 from gi.repository import Gdk
 from gi.repository import GdkPixbuf
 from gi.repository import Gtk
 from gi.repository import GLib
-from gi.repository import GConf
+from gi.repository import Gio
 from gi.repository import GObject
 
 from sugar3 import env
@@ -559,8 +567,8 @@ def get_battery_level():
 
 
 def get_sound_level():
-    client = GConf.Client.get_default()
-    return client.get_int('/desktop/sugar/sound/volume')
+    settings = Gio.Settings.new('org.sugar.desktop')
+    return settings.get_int('sound-volume')
 
 
 def is_clipboard_text_available():
@@ -986,8 +994,8 @@ def get_launch_count(activity):
 
 
 def get_colors():
-    client = GConf.Client.get_default()
-    return XoColor(client.get_string('/desktop/sugar/user/color'))
+    settings = Gio.Settings.new('org.sugar.desktop')
+    return XoColor(settings.get_string('user-color'))
 
 
 def get_nick():
@@ -1153,12 +1161,12 @@ def find_string(path, string):
 
 class DeviceModel(GObject.GObject):
     __gproperties__ = {
-        'level': (int, None, None, 0, 100, 0, GObject.PARAM_READABLE),
+        'level': (int, None, None, 0, 100, 0, GObject.ParamFlags.READABLE),
         'time-remaining': (int, None, None, 0, GLib.MAXINT32, 0,
-                           GObject.PARAM_READABLE),  # unit: seconds
-        'charging': (bool, None, None, False, GObject.PARAM_READABLE),
-        'discharging': (bool, None, None, False, GObject.PARAM_READABLE),
-        'present': (bool, None, None, False, GObject.PARAM_READABLE),
+                           GObject.ParamFlags.READABLE),  # unit: seconds
+        'charging': (bool, None, None, False, GObject.ParamFlags.READABLE),
+        'discharging': (bool, None, None, False, GObject.ParamFlags.READABLE),
+        'present': (bool, None, None, False, GObject.ParamFlags.READABLE),
     }
 
     __gsignals__ = {

--- a/utils.py
+++ b/utils.py
@@ -16,7 +16,7 @@ import subprocess
 import dbus
 import stat
 import glob
-import urllib
+import urllib.request, urllib.parse, urllib.error
 from random import uniform
 import tempfile
 import cairo
@@ -545,7 +545,7 @@ def is_landscape():
 
 
 def get_safe_text(text):
-    return urllib.pathname2url(text.encode('ascii', 'xmlcharrefreplace'))
+    return urllib.request.pathname2url(text.encode('ascii', 'xmlcharrefreplace'))
 
 
 def get_battery_level():
@@ -1106,7 +1106,7 @@ def uitree_dump():
     try:
         return json.loads(dbus.Interface(proxy, _DBUS_SERVICE).Dump())
     except Exception as e:
-        print ('ERROR calling Dump: %s' % e)
+        print('ERROR calling Dump: %s' % e)
         # _logger.error('ERROR calling Dump: %s' % e)
     return ''
 


### PR DESCRIPTION
This PR addresses multiple compatibility issues and warnings in the activity:  

- Added gi.require_version() for Vte, Wnck, SugarExt, Gio, TelepathyGLib, and Gdk to resolve PyGIWarnings.  
- Replaced deprecated GObject.property with GObject.Property.  
- Migrated from GConf to GSettings (Gio) for settings management.  
- Ensured Gdk and Gtk versions are correctly set to avoid conflicts.  

### **Testing**  
- Tested the activity within Sugar to ensure smooth functionality.  
- Manually executed relevant files (`activity.py`, `utils.py`, `textchannelwrapper.py`, `graphics.py`) to verify there are no errors or warnings.  

This update improves stability and ensures compatibility with Python 3 and modern GI bindings. Let me know if any further changes are required! 

Please review @quozl 
